### PR TITLE
Code Highlighting and Docs Navigation Fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
-end_of_line = lf
+end_of_line = crlf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -24,3 +24,7 @@
 @import "layouts/pages";
 @import "layouts/posts";
 @import "layouts/sidebar";
+
+/* Import Chroma */
+@import "components/code-light";
+@import "components/code-dark";

--- a/assets/scss/components/code-dark.scss
+++ b/assets/scss/components/code-dark.scss
@@ -1,0 +1,86 @@
+// Chroma 'dracula' style (modified)
+
+body.dark {
+/* Background */ .chroma { color: #f8f8ff; }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err {  }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ .chroma .k { color: #ff79c6 }
+/* KeywordConstant */ .chroma .kc { color: #ff79c6 }
+/* KeywordDeclaration */ .chroma .kd { color: #8be9fd; font-style: italic }
+/* KeywordNamespace */ .chroma .kn { color: #ff79c6 }
+/* KeywordPseudo */ .chroma .kp { color: #ff79c6 }
+/* KeywordReserved */ .chroma .kr { color: #ff79c6 }
+/* KeywordType */ .chroma .kt { color: #8be9fd }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na { color: #50fa7b }
+/* NameBuiltin */ .chroma .nb { color: #8be9fd; font-style: italic }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #50fa7b }
+/* NameConstant */ .chroma .no {  }
+/* NameDecorator */ .chroma .nd {  }
+/* NameEntity */ .chroma .ni {  }
+/* NameException */ .chroma .ne {  }
+/* NameFunction */ .chroma .nf { color: #50fa7b }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl { color: #8be9fd; font-style: italic }
+/* NameNamespace */ .chroma .nn {  }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py {  }
+/* NameTag */ .chroma .nt { color: #ff79c6 }
+/* NameVariable */ .chroma .nv { color: #8be9fd; font-style: italic }
+/* NameVariableClass */ .chroma .vc { color: #8be9fd; font-style: italic }
+/* NameVariableGlobal */ .chroma .vg { color: #8be9fd; font-style: italic }
+/* NameVariableInstance */ .chroma .vi { color: #8be9fd; font-style: italic }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l {  }
+/* LiteralDate */ .chroma .ld {  }
+/* LiteralString */ .chroma .s { color: #f1fa8c }
+/* LiteralStringAffix */ .chroma .sa { color: #f1fa8c }
+/* LiteralStringBacktick */ .chroma .sb { color: #f1fa8c }
+/* LiteralStringChar */ .chroma .sc { color: #f1fa8c }
+/* LiteralStringDelimiter */ .chroma .dl { color: #f1fa8c }
+/* LiteralStringDoc */ .chroma .sd { color: #f1fa8c }
+/* LiteralStringDouble */ .chroma .s2 { color: #f1fa8c }
+/* LiteralStringEscape */ .chroma .se { color: #f1fa8c }
+/* LiteralStringHeredoc */ .chroma .sh { color: #f1fa8c }
+/* LiteralStringInterpol */ .chroma .si { color: #f1fa8c }
+/* LiteralStringOther */ .chroma .sx { color: #f1fa8c }
+/* LiteralStringRegex */ .chroma .sr { color: #f1fa8c }
+/* LiteralStringSingle */ .chroma .s1 { color: #f1fa8c }
+/* LiteralStringSymbol */ .chroma .ss { color: #f1fa8c }
+/* LiteralNumber */ .chroma .m { color: #bd93f9 }
+/* LiteralNumberBin */ .chroma .mb { color: #bd93f9 }
+/* LiteralNumberFloat */ .chroma .mf { color: #bd93f9 }
+/* LiteralNumberHex */ .chroma .mh { color: #bd93f9 }
+/* LiteralNumberInteger */ .chroma .mi { color: #bd93f9 }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #bd93f9 }
+/* LiteralNumberOct */ .chroma .mo { color: #bd93f9 }
+/* Operator */ .chroma .o { color: #ff79c6 }
+/* OperatorWord */ .chroma .ow { color: #ff79c6 }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #6272a4 }
+/* CommentHashbang */ .chroma .ch { color: #6272a4 }
+/* CommentMultiline */ .chroma .cm { color: #6272a4 }
+/* CommentSingle */ .chroma .c1 { color: #6272a4 }
+/* CommentSpecial */ .chroma .cs { color: #6272a4 }
+/* CommentPreproc */ .chroma .cp { color: #ff79c6 }
+/* CommentPreprocFile */ .chroma .cpf { color: #ff79c6 }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #8b080b }
+/* GenericEmph */ .chroma .ge { text-decoration: underline }
+/* GenericError */ .chroma .gr {  }
+/* GenericHeading */ .chroma .gh { font-weight: bold }
+/* GenericInserted */ .chroma .gi { font-weight: bold }
+/* GenericOutput */ .chroma .go { color: #44475a }
+/* GenericPrompt */ .chroma .gp {  }
+/* GenericStrong */ .chroma .gs {  }
+/* GenericSubheading */ .chroma .gu { font-weight: bold }
+/* GenericTraceback */ .chroma .gt {  }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w {  }
+}

--- a/assets/scss/components/code-light.scss
+++ b/assets/scss/components/code-light.scss
@@ -1,0 +1,84 @@
+// Chroma 'pygments' style
+
+/* Background */ .chroma {  }
+/* Other */ .chroma .x {  }
+/* Error */ .chroma .err {  }
+/* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ .chroma .k { color: #008000; font-weight: bold }
+/* KeywordConstant */ .chroma .kc { color: #008000; font-weight: bold }
+/* KeywordDeclaration */ .chroma .kd { color: #008000; font-weight: bold }
+/* KeywordNamespace */ .chroma .kn { color: #008000; font-weight: bold }
+/* KeywordPseudo */ .chroma .kp { color: #008000 }
+/* KeywordReserved */ .chroma .kr { color: #008000; font-weight: bold }
+/* KeywordType */ .chroma .kt { color: #b00040 }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na { color: #7d9029 }
+/* NameBuiltin */ .chroma .nb { color: #008000 }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: #0000ff; font-weight: bold }
+/* NameConstant */ .chroma .no { color: #880000 }
+/* NameDecorator */ .chroma .nd { color: #aa22ff }
+/* NameEntity */ .chroma .ni { color: #999999; font-weight: bold }
+/* NameException */ .chroma .ne { color: #d2413a; font-weight: bold }
+/* NameFunction */ .chroma .nf { color: #0000ff }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl { color: #a0a000 }
+/* NameNamespace */ .chroma .nn { color: #0000ff; font-weight: bold }
+/* NameOther */ .chroma .nx {  }
+/* NameProperty */ .chroma .py {  }
+/* NameTag */ .chroma .nt { color: #008000; font-weight: bold }
+/* NameVariable */ .chroma .nv { color: #19177c }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l {  }
+/* LiteralDate */ .chroma .ld {  }
+/* LiteralString */ .chroma .s { color: #ba2121 }
+/* LiteralStringAffix */ .chroma .sa { color: #ba2121 }
+/* LiteralStringBacktick */ .chroma .sb { color: #ba2121 }
+/* LiteralStringChar */ .chroma .sc { color: #ba2121 }
+/* LiteralStringDelimiter */ .chroma .dl { color: #ba2121 }
+/* LiteralStringDoc */ .chroma .sd { color: #ba2121; font-style: italic }
+/* LiteralStringDouble */ .chroma .s2 { color: #ba2121 }
+/* LiteralStringEscape */ .chroma .se { color: #bb6622; font-weight: bold }
+/* LiteralStringHeredoc */ .chroma .sh { color: #ba2121 }
+/* LiteralStringInterpol */ .chroma .si { color: #bb6688; font-weight: bold }
+/* LiteralStringOther */ .chroma .sx { color: #008000 }
+/* LiteralStringRegex */ .chroma .sr { color: #bb6688 }
+/* LiteralStringSingle */ .chroma .s1 { color: #ba2121 }
+/* LiteralStringSymbol */ .chroma .ss { color: #19177c }
+/* LiteralNumber */ .chroma .m { color: #666666 }
+/* LiteralNumberBin */ .chroma .mb { color: #666666 }
+/* LiteralNumberFloat */ .chroma .mf { color: #666666 }
+/* LiteralNumberHex */ .chroma .mh { color: #666666 }
+/* LiteralNumberInteger */ .chroma .mi { color: #666666 }
+/* LiteralNumberIntegerLong */ .chroma .il { color: #666666 }
+/* LiteralNumberOct */ .chroma .mo { color: #666666 }
+/* Operator */ .chroma .o { color: #666666 }
+/* OperatorWord */ .chroma .ow { color: #aa22ff; font-weight: bold }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: #408080; font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: #408080; font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: #408080; font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: #408080; font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: #408080; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: #bc7a00 }
+/* CommentPreprocFile */ .chroma .cpf { color: #bc7a00 }
+/* Generic */ .chroma .g {  }
+/* GenericDeleted */ .chroma .gd { color: #a00000 }
+/* GenericEmph */ .chroma .ge { font-style: italic }
+/* GenericError */ .chroma .gr { color: #ff0000 }
+/* GenericHeading */ .chroma .gh { color: #000080; font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: #00a000 }
+/* GenericOutput */ .chroma .go { color: #888888 }
+/* GenericPrompt */ .chroma .gp { color: #000080; font-weight: bold }
+/* GenericStrong */ .chroma .gs { font-weight: bold }
+/* GenericSubheading */ .chroma .gu { color: #800080; font-weight: bold }
+/* GenericTraceback */ .chroma .gt { color: #0044dd }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: #bbbbbb }

--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -1,24 +1,24 @@
 [[docs]]
   name = "Prólogo"
-  weight = 10
+  weight = 1
   identifier = "prologo"
   url = "/docs/prologo/"
 
 [[docs]]
   name = "Intro a la Programación"
-  weight = 20
+  weight = 2
   identifier = "intro"
   url = "/docs/intro/"
 
 [[docs]]
   name = "Tema2"
-  weight = 30
+  weight = 3
   identifier = "tema2"
   url = "/docs/tema2/"
 
 [[docs]]
   name = "Anexos"
-  weight = 90
+  weight = 999
   identifier = "anexos"
   url = "/docs/anexos/"
 
@@ -26,25 +26,25 @@
 [[main]]
   name = "Videos"
   url = "/blog/"
-  weight = 10
+  weight = 1
 
 [[main]]
   name = "Apunte"
   url = "/docs/prologo/intro"
-  weight = 20
+  weight = 2
 
   [[main]]
   name = "Recursos"
   url = "/recursos/contests/intro"
-  weight = 25
+  weight = 3
 
 [[main]]
   name = "Acerca"
   url = "/acerca"
-  weight = 30
+  weight = 4
 
 [[social]]
   name = "GitHub"
   pre = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" class=\"feather feather-github\"><path d=\"M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22\"></path></svg>"
   url = "https://github.com/progcompuch/apunte"
-  weight = 20
+  weight = 1

--- a/content/docs/intro/c++.md
+++ b/content/docs/intro/c++.md
@@ -3,11 +3,10 @@ title: Entendiendo C++
 lead: ''
 date: 2020-10-06T08:48:45.000+00:00
 images: []
-weight: "8"
+weight: 101
 menu:
   docs:
     parent: intro
-    weight: 2
 
 ---
 Para partir programando, primero debemos entender en qué formato se programa. Para los programas en c++ solo requieres crear un archivo de texto cualquiera, en el editor de texto que elijas (funciona hasta en un block de notas), cuyo nombre termine con la extención ".cpp" (del inglés "cee plus plus"). Este archivo contendrá la serie de instrucciones que se ejecutarán paso a paso.

--- a/content/docs/intro/intro.md
+++ b/content/docs/intro/intro.md
@@ -3,11 +3,10 @@ title: Introducción a la Programación
 lead: ''
 date: 2021-05-15T14:00:45.000+00:00
 images: []
-weight: "24"
+weight: 100
 menu:
   docs:
     parent: intro
-    weight: 1
 
 ---
 En esta sección se explican todos los conceptos previos necesarios para empezar a resolver problemas de programación. Sientete libre de omitir esta parte si sabes como funciona la programación o has tenido experiencia programado antes.
@@ -16,7 +15,7 @@ En esta sección se explican todos los conceptos previos necesarios para empezar
 
 La programación está definida a partir de pequeños bloques de código, una serie de instrucciones que se ejecutan una detrás de la otra. La manera en que se ejecutan estas instrucciones se define como un "_algoritmo_", lo que nos describe la forma en que se resuelve un problema, es decir la lógica que se utilizó para resolver el problema, pero no necesariamente de su implementación. Mientras que la lógica tras la resolución de un problema puede ser la misma, no necesariamente va a estar implementada de la misma manera, esa es la diferencia con el "_programa_" es decir, el código ya escrito, listo para ser interpretado, pues mientras que pueden representar el mismo algoritmo, el código puede estar escrito en lenguajes de programación distinto (tales como c++, kotlin o python) o usar una cantidad de valores distintos.
 
-A la hora de programar, debemos crear una serie de instrucciones, las cuales deben usar cierta información dada para obtener un resultado (al que llamamos input), por ejemplo, si queremos calcular el perimetro de un cuadrado tenemos que multiplicar por 4 el lado de un cuadrado: en este caso el "input" de nuestro programa será el largo de un lado del cuadrado, tenemos que multiplicar por 4 y luego entregar dicho resultado (es decir, el "output"). 
+A la hora de programar, debemos crear una serie de instrucciones, las cuales deben usar cierta información dada para obtener un resultado (al que llamamos input), por ejemplo, si queremos calcular el perimetro de un cuadrado tenemos que multiplicar por 4 el lado de un cuadrado: en este caso el "input" de nuestro programa será el largo de un lado del cuadrado, tenemos que multiplicar por 4 y luego entregar dicho resultado (es decir, el "output").
 
 Aquí identificamos tres instrucciones: leer un número, multiplicarlo por 4, y entregar el perímetro. Aquellos valores que cambian, como en este caso lo es el lado del cuadrado, serán nuestras *variables*, valores que el programa almacena en un espacio definido y que tienen un nombre asociado. A esta le podemos poner "lado", para que así retornemos 4*lado, por ejemplo. Estas variables tienen distintos tipos, y se comportan diferente en cada lenguaje de programación, pero en este caso describiremos los principalmente usados en programación competitiva en c++.
 
@@ -26,7 +25,7 @@ Aquí identificamos tres instrucciones: leer un número, multiplicarlo por 4, y 
   * *int*: Se usa para enteros (_integers_ en inglés) y cubren valores entre -2,147,483,648 y 2,147,483,647 (correspondiendo al 2<sup>31</sup>-1). Como regla general, se usa para valores entre el -2\*10<sup>10</sup> y 2\*10<sup>10</sup>. Tienen la desventaja de no poder almacenar valores decimales pero son útiles en la mayoría de las situaciones. La operación de estos siempre te dará resultado entero, por lo que hay que tener ojo con la division entera (3/2 = 1 bajo esta lógica).
   * *long long int*: Usualmente conocido simplemente como "_long long_", se usa en caso de que necesites un rango mayor que el int, el rango es de –9, 223, 372, 036, 854, 775, 808 a 9, 223, 372, 036, 854, 775, 807. Esto nos permite trabajar con números entre -10<sup>18</sup> y 10<sup>18</sup>.
   * *float*: Este tipo se usa para trabajar números con decimales. Por las limitaciones de la memoria este número contiene un valor aproximado hasta cierto decimal, pero no tiende a importar tanto pues generalmente se usa para calculos numericos no tan precisos, considerando el rango de decimales.
-  
+
 * **Cadenas**: Se usan para registrar "palabras" o "caracteres". Puede incluir letras, números y simbolos, por lo que hay que tener cuidado a la hora de manipular números como variables de este tipo, pues no se comportan igual (no es lo mismo el número 2 que el caracter "2", podemos sumar números pero no caracteres). En esta categoría tenemos dos tipos:
   * *char*: La unidad mínima, almacenando un único caracter. Ej: "h", "2", "o", etc.
   * *string*: El tipo más usado de las cadenas, es un arreglo (es decir, una serie ordenada) de "char"s, con lo que puedes procesar varios caracteres seguidos. Ej: "hola", "c++", "123", "h0l4", etc.

--- a/content/docs/prologo/intro.md
+++ b/content/docs/prologo/intro.md
@@ -3,11 +3,10 @@ title: Prólogo
 lead: ''
 date: 2020-10-06T08:48:45.000+00:00
 images: []
-weight: "8"
+weight: 1
 menu:
   docs:
     parent: prologo
-    weight: 11
 
 ---
 Este apunte recoge los contenidos usualmente vistos los cursos de **Taller de Programación Competitiva** del [Departamento de Ciencias de la Computación](https://dcc.uchile.cl) de la [Facultad de Ciencias Físicas y Matemáticas](https://ingenieria.uchile.cl) de la [Universidad de Chile](https://uchile.cl). El objetivo de estos cursos es acercar al estudiante al área de la programación competitiva, aplicando eficazmente estructuras de datos y algoritmos para resolver en corto tiempo problemas de programación complejos, limitados en tiempo y memoria computacional.


### PR DESCRIPTION
## Fixes:
 - The project uses CRLF, so `.editorconfig` was updated to match it
 - The docs navigation (bottom page buttons) didn't have the right order because of bad setting of the pages weights.

## Added:
 -  Added Chroma styles for code highlighting, dracula and pygments styles were used for dark and light modes, respectively. [List of available styles](https://xyproto.github.io/splash/docs/)