### PR TITLE
Footer in bottom in home page

### DIFF
--- a/assets/scss/common/_global.scss
+++ b/assets/scss/common/_global.scss
@@ -76,6 +76,14 @@ h6,
 
 body {
   padding-top: 3.5625rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 100vh;
+}
+
+main {
+  flex-grow: 1;
 }
 
 .docs-sidebar {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,11 +14,11 @@
   {{ end -}}
   <body class="{{ .Scratch.Get "class" }}">
     {{ partial "header/header.html" . }}
-    <div class="wrap container" role="document">
+    <main class="wrap container" role="document">
       <div class="content">
         {{ block "main" . }}{{ end }}
       </div>
-    </div>
+    </main>
     {{ block "sidebar-prefooter" . }}{{ end }}
     {{ block "sidebar-footer" . }}{{ end }}
     {{ partial "footer/footer.html" . }}


### PR DESCRIPTION
I made that footer goes in bottom (as meant to be). 

Before:
![image](https://user-images.githubusercontent.com/41976055/205958917-7e4850f0-c467-4a8a-994f-af7a72c20c80.png)

After:
![image](https://user-images.githubusercontent.com/41976055/205959000-2399a008-7d67-4f31-96a8-44f42759cabc.png)

Also I made HTML more semantic changing tag from `div` to `main` of the container of _main content_. 