### PR TITLE
Añadir disclaimer

### DIFF
--- a/content/apunte/introduccion_a_cpp/compilacion_y_editores/index.md
+++ b/content/apunte/introduccion_a_cpp/compilacion_y_editores/index.md
@@ -32,6 +32,9 @@ Aunque varias distribuciones de Linux vienen con `GCC`,
 la instalación dependerá de tu gestor de paquetes:
 * `apt`: La forma recomendada es instalar el paquete de desarrollo `build-essential`:
 `sudo apt install build-essential`
+
+  Nota: Si es tu primera vez instalando un paquete, debes correr `sudo apt update` primero.
+  
 * `pacman`: Directamente podemos instalar el paquete `gcc`:
 `pacman -S gcc`
 * `yum`: Parecido a `pacman`: `yum -y install gcc`


### PR DESCRIPTION
Si tienes Ubuntu recién instalado, debes actualizar los repositorios antes de poder instalar g++, por lo que añadí una nota que explica esto.