### PR TITLE
Actualizar MinGW

### DIFF
--- a/content/apunte/introduccion/compilacion_y_editores/index.md
+++ b/content/apunte/introduccion/compilacion_y_editores/index.md
@@ -57,7 +57,7 @@ Para Windows, hay tres alternativas notables para obtener la GCC:
   En WSL lo más común es instalar Ubuntu, de ahí puedes seguir las instrucciones de Linux que están más arriba.
   1. MinGW (Minimalist GNU for Windows): Es una implementación de los 
   compiladores de la GCC para Windows. 
-  Puedes descargarlo en [Sourceforge](https://sourceforge.net/projects/mingw/), 
+  Puedes descargarlo en [GitHub](https://github.com/skeeto/w64devkit), 
   y la instalación es relativamente sencilla.
   1. Cygwin: Es una colección de herramientas (entre ellas GCC) para proporcionar un
   entorno tipo UNIX en Windows. Puedes descargarlo [en su sitio web](https://www.cygwin.com/).


### PR DESCRIPTION
La versión de sourceforge es muy vieja y es menos intuitiva porque te instala un instalador. Esta tampoco es 100% intuitiva pero da un paso en la dirección correcta y usa la última versión de g++. Queda pendiente hacer un tutorial apropiado de cómo instalar MingGW.