### PR TITLE
Add title to University icons

### DIFF
--- a/assets/js/ratings.js
+++ b/assets/js/ratings.js
@@ -100,7 +100,14 @@ function createTableRow(nickname, rating, judge, organization, femeligible, icpc
 
     row.innerHTML = `
         <td><span class="${getRatingClass(judge, rating)}">${nickname}</span></td>
-        <td><img src="/images/universities/${organization}.png" class="university-logo"></td>
+        <td>
+            <img
+                src="/images/universities/${organization}.png"
+                alt="${organization}"
+                title="${organization}"
+                class="university-logo"
+            >
+        </td>
         <td><span class="${getRatingClass(judge, rating)}">${rating}</span></td>
     `;
     return { nickname, rating, row };

--- a/assets/js/teamIcpc.js
+++ b/assets/js/teamIcpc.js
@@ -57,7 +57,14 @@ function updateTeamTable(teams) {
 
         row.innerHTML = `
             <td><span class="team-name">${team.name}</span></td>
-            <td><img src="/images/universities/${team.organization}.png" class="university-logo"></td>
+            <td>
+                <img
+                    src="/images/universities/${team.organization}.png"
+                    alt="${team.organization}"
+                    title="${team.organization}"
+                    class="university-logo"
+                >
+            </td>
             <td>${membersHtml}</td>
         `;
 
@@ -97,7 +104,14 @@ function createTableRow(nickname, rating, judge, organization, femeligible, icpc
 
     row.innerHTML = `
         <td><span class="${getRatingClass(judge, rating)}">${nickname}</span></td>
-        <td><img src="/images/universities/${organization}.png" class="university-logo"></td>
+        <td>
+            <img
+                src="/images/universities/${organization}.png"
+                alt="${organization}"
+                title="${organization}"
+                class="university-logo"
+            >
+        </td>
         <td><span class="${getRatingClass(judge, rating)}">${rating}</span></td>
     `;
     return { nickname, rating, row };

--- a/assets/js/training.js
+++ b/assets/js/training.js
@@ -16,7 +16,7 @@ const trainingNames = [
     ],
     [
         "Grafos 2: Minimum Spanning Tree / Camino más corto",
-        "Teoría de números / Conteo", 
+        "Teoría de números / Conteo",
         "Programación Dinámica 2",
         "Estructuras de Datos 2",
         "algoritmo de mo"
@@ -280,7 +280,7 @@ const contests_ids = [
         "25",
         "26",
         "27",
-        "28", 
+        "28",
         "29",
         "30",
         "31",
@@ -336,7 +336,7 @@ async function loadData(data, _lvlindxpath){
         contest_data = data[contestId];
 
         let frow = table.getElementsByTagName('tr')[0];
-        
+
         let totalsNames = frow.children;
 
         if (totalsNames.length == 0){
@@ -411,6 +411,7 @@ async function loadData(data, _lvlindxpath){
             let img = document.createElement("img");
             img.src = `/images/universities/${userUniversity}.png`;
             img.alt = userUniversity;
+            img.title = userUniversity;
             img.classList.add("university-logo");
             userCell.appendChild(img);
             ccol ++;


### PR DESCRIPTION
## Summary

Agrega título a los íconos de universidad para poder identificarlas más facilmente.

## Basic example
<img width="277" height="71" alt="image" src="https://github.com/user-attachments/assets/99e72796-4103-44b1-af93-11198ddd4c45" />


## Motivation

Accesibilidad :3

## Checks

- [x] Read [Create a Pull Request](https://getdoks.org/docs/contributing/how-to-contribute/#create-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test`
